### PR TITLE
Added the function to automatically display the translation panel.

### DIFF
--- a/simple-translate/_locales/en/messages.json
+++ b/simple-translate/_locales/en/messages.json
@@ -35,6 +35,12 @@
     "ifShowCandidateCaptionLabel": {
         "message": "Show multiple translation candidates when a single word is translated."
     },
+    "ifAutoTranslate": {
+        "message": "Automatically display translation panel"
+    },
+    "ifAutoTranslateLabel": {
+        "message": "Directly display the translation panel without displaying the button."
+    },
     "ifShowButtonLabel": {
         "message": "Display the button when text is selected"
     },

--- a/simple-translate/_locales/ja_JP/messages.json
+++ b/simple-translate/_locales/ja_JP/messages.json
@@ -47,6 +47,12 @@
     "ifCheckLangCaptionLabel": {
         "message": "選択したテキストの言語を検出し，翻訳先言語と同じ場合はボタンを表示しません。"
     },
+    "ifAutoTranslate": {
+        "message": "自動的に翻訳パネルを表示する"
+    },
+    "ifAutoTranslateLabel": {
+        "message": "ボタンを表示せずに直接翻訳パネルを表示します。"
+    },
     "ifShowMenuLabel": {
         "message": "コンテキストメニューを表示する"
     },

--- a/simple-translate/options/options.html
+++ b/simple-translate/options/options.html
@@ -102,6 +102,18 @@
                                     </label>
                                 </div>
                             </li>
+                            <li class=optionContainer>
+                                <div class=optionText>
+                                    <p class=ifAutoTranslate>自動的に翻訳パネルを表示する</p>
+                                    <p class="caption ifAutoTranslateCaptionLabel">ボタンを表示せずに直接翻訳パネルを表示します。</p>
+                                </div>
+                                <div class=optionForm>
+                                    <label>
+                                    <input type=checkbox id=ifAutoTranslate class=saveByChange>
+                                    <span class=checkbox></span>
+                                    </label>
+                                </div>
+                            </li>
                         </ul>
 
                         <br>

--- a/simple-translate/simple-translate.js
+++ b/simple-translate/simple-translate.js
@@ -24,9 +24,14 @@ function Select(e) {
 
         if ((selectionWord.length !== 0) && (e.button == 0) && (e.target.id !== "simple-translate-panel") && (e.target.parentElement.id !== "simple-translate-panel")) { //選択範囲が存在かつ左クリックかつパネル以外のとき
             clickPosition = e;
-            if (S.get().ifShowButton) { //ボタンを表示
+            if (S.get().ifShowButton) { 
                 checkLang().then(function (results) {
-                    if (results) popupButton(e);
+                    if (results && S.get().ifAutoTranslate) { // 自動翻訳パネル表示がOnならshowPanel()
+                        translate();
+                        showPanel(e);
+                    } else if (results) { // Offならボタンを表示
+                        popupButton(e);
+                    }
                 });
             }
         }


### PR DESCRIPTION
![noclick](https://i.gyazo.com/b3b92dfeb0fbeb6a3a6fa139988def14.png)

![noclick-gif](https://i.gyazo.com/005915b87eff11cde09b53a5a5740667.gif)
It can quickly examine English words like a dictionary.

Chromeの[Google翻訳拡張機能](https://chrome.google.com/webstore/detail/google-translate/aapbdbdomjkkjkaonfhkkikfgjllcleb/reviews)のような選択のみで表示してくれるプラグインがなく困っていたため、試した中で一番使いやすかったこちらのアドオンに追加させていただきました。

よろしくお願いします。