### PR TITLE
Fix the inserted <div> covering origin content

### DIFF
--- a/src/content/index.js
+++ b/src/content/index.js
@@ -2,5 +2,5 @@ import React from "react";
 import ReactDOM from "react-dom";
 import TranslateContainer from "./components/TranslateContainer";
 
-document.body.insertAdjacentHTML("afterend", "<div id='simple-translate'></div>");
+document.body.insertAdjacentHTML("beforeend", "<div id='simple-translate'></div>");
 ReactDOM.render(<TranslateContainer />, document.getElementById("simple-translate"));


### PR DESCRIPTION
When inserting \<div\> after \<body\> element, it will create a new \<body\> to contain the new \<div\> element. This may cause part of the origin website content to be covered. So just use `beforeend` instead of `afterend` to avoid that.