### PR TITLE
Only translate text when specified key pressed

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -95,6 +95,30 @@
   "isDisabledInTextFieldsCaptionLabel": {
     "message": "Don't display translation button or panel when selecting text in a text field."
   },
+  "ifOnlyTranslateWhenShiftPressedLabel": {
+    "message": "Translate on specified key pressed"
+  },
+  "ifOnlyTranslateWhenShiftPressedCaptionLabel": {
+    "message": "Only display translation on Shift key pressed"
+  },
+  "specifiedKeyLabel": {
+    "message": "Specified Key"
+  },
+  "specifyKeyLabel": {
+    "message": "Specify Key"
+  },
+  "shiftLabel": {
+    "message": "Shift"
+  },
+  "ctrlLabel": {
+    "message": "Ctrl"
+  },
+  "altLabel": {
+    "message": "Alt"
+  },
+  "cmdLabel": {
+    "message": "Command"
+  },
   "disableUrlListLabel": {
     "message": "URL list to disable translation"
   },

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -38,6 +38,26 @@ const handleMouseUp = async e => {
     if (isInContentEditable()) return;
   }
 
+  if (getSettings("ifOnlyTranslateWhenShiftPressed")) {
+    const spKey = getSettings("specifiedKey")
+    switch(spKey){
+      case "shift":
+        if (!e.shiftKey) return;
+        break;
+      case "alt":
+        if (!e.altKey) return;
+        break;
+      case "ctrl":
+        if (!e.ctrlKey) return;
+        break;
+      case "cmd":
+        if (!e.metaKey) return;
+        break;
+      default:
+          break;
+    }
+  }
+
   const clickedPosition = { x: e.clientX, y: e.clientY };
   const selectedPosition = getSelectedPosition();
   showTranslateContainer(selectedText, selectedPosition, clickedPosition);

--- a/src/settings/defaultSettings.js
+++ b/src/settings/defaultSettings.js
@@ -88,6 +88,44 @@ export default [
         ]
       },
       {
+        title: "specifiedKeyLabel",
+        captions: [],
+        type: "none",
+        childElements:[
+          {
+            id: "ifOnlyTranslateWhenShiftPressed",
+            title: "ifOnlyTranslateWhenShiftPressedLabel",
+            captions: ["ifOnlyTranslateWhenShiftPressedCaptionLabel"],
+            type: "checkbox",
+            default: false
+          },
+          {
+            id: "specifiedKey",
+            title: "specifiedKeyLabel",
+            captions: [],
+            type: "select",
+            default: "shift",
+            options: [
+              {
+                name: "shiftLabel",
+                value: "shift"
+              },
+              {
+                name: "ctrlLabel",
+                value: "ctrl"
+              },
+              {
+                name: "altLabel",
+                value: "alt"
+              },
+              {
+                name: "cmdLabel",
+                value: "cmd"
+              }]
+          }
+        ]
+      },
+      {
         id: "ifChangeSecondLangOnPage",
         title: "ifChangeSecondLangLabel",
         captions: ["ifChangeSecondLangOnPageCaptionLabel"],


### PR DESCRIPTION
Solution to [translating by Shift key](https://github.com/sienori/simple-translate/issues/149#issuecomment-752368907).