### PR TITLE
feat: Add ignored document lang option

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -137,6 +137,12 @@
   "secondTargetLangCaptionLabel": {
     "message": "Select the second target language."
   },
+  "ignoredDocumentLangLabel": {
+    "message": "Ignore documents in the following languages"
+  },
+  "ignoredDocumentLangCaptionLabel": {
+    "message": "Comma separated languages that do not need to be translated."
+  },
   "waitTimeLabel": {
     "message": "Waiting time to translate"
   },

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -28,7 +28,11 @@ const handleMouseUp = async e => {
   if (!isLeftClick) return;
   if (isInPasswordField) return;
   if (isInThisElement) return;
+
   removeTranslatecontainer();
+
+  const ignoredDocumentLang = getSettings('ignoredDocumentLang').split(',').map(s => s.trim()).filter(s => !!s)
+  if (!!document.documentElement.lang && ignoredDocumentLang.includes(document.documentElement.lang)) return;
 
   const selectedText = getSelectedText();
   prevSelectedText = selectedText;

--- a/src/settings/defaultSettings.js
+++ b/src/settings/defaultSettings.js
@@ -40,6 +40,15 @@ export default [
         useRawOptionName: true
       },
       {
+        id: "ignoredDocumentLang",
+        title: "ignoredDocumentLangLabel",
+        captions: ["ignoredDocumentLangCaptionLabel"],
+        type: "text",
+        default: "",
+        placeholder: "en, ru, ch",
+        new: true,
+      },
+      {
         id: "ifShowCandidate",
         title: "ifShowCandidateLabel",
         captions: ["ifShowCandidateCaptionLabel"],


### PR DESCRIPTION
## Description
This option allows you to list the locales for which you do not need to
apply translation.

## Use case:
I am fluent in several languages. And I'm annoyed that the application is constantly translating one of these languages into my native language. In addition, this leads to exceeding the API limit. And when I really need a translation, it's not available.

This option will allow you to list several languages that can be ignored and not translated.

## Imperfection
To increase productivity and reduce API requests the language detections applies to the entire document based on the `lang` attribute, not based on the selected snippet. 