### PR TITLE
Disable translate for elements with `translate="no"` attribute

### DIFF
--- a/src/content/index.js
+++ b/src/content/index.js
@@ -30,6 +30,10 @@ const handleMouseUp = async e => {
   const inCodeElement = e.target.tagName === "CODE" || !!e.target.closest("code");
   if (inCodeElement && getSettings("isDisabledInCodeElement")) return;
 
+
+  const isTranslateDisabled = e.target.translate === undefined ? e.target.getAttribute('translate') === 'no' : e.target.translate === false;
+  if (isTranslateDisabled) return;
+
   const isInThisElement =
     document.querySelector("#simple-translate") &&
     document.querySelector("#simple-translate").contains(e.target);


### PR DESCRIPTION
This disables automatic translation on elements that the site marks as not being translated.

Example:
```html
<footer>
  <small>© 2020 <span translate="no">BrandName</span></small>
</footer>
```