### PR TITLE
Language definition based on the closest `lang` attribute

### DIFF
--- a/src/content/index.js
+++ b/src/content/index.js
@@ -39,7 +39,7 @@ const handleMouseUp = async e => {
 
   const ignoredDocumentLang = getSettings("ignoredDocumentLang").split(",").map(s => s.trim()).filter(s => !!s);
   if (ignoredDocumentLang.length) {
-    const ignoredLangSelector = ignoredDocumentLang.map(lang = `[lang="${lang}"]`).join(',')
+    const ignoredLangSelector = ignoredDocumentLang.map(lang => `[lang="${lang}"]`).join(',')
     if (!!e.target.closest(ignoredLangSelector)) return;
   }
 

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -38,7 +38,10 @@ const handleMouseUp = async e => {
   removeTranslatecontainer();
 
   const ignoredDocumentLang = getSettings("ignoredDocumentLang").split(",").map(s => s.trim()).filter(s => !!s);
-  if (!!document.documentElement.lang && ignoredDocumentLang.includes(document.documentElement.lang)) return;
+  if (ignoredDocumentLang.length) {
+    const ignoredLangSelector = ignoredDocumentLang.map(lang = `[lang="${lang}"]`).join(',')
+    if (!!e.target.closest(ignoredLangSelector)) return;
+  }
 
   const selectedText = getSelectedText();
   prevSelectedText = selectedText;


### PR DESCRIPTION
This will allow relying not on the language of the root document, but on a specific section.

Example:

```html
<html lang="en">
  <!-- ignoredDocumentLang = 'ua' -->

  <p>This text will be translated</p>
  <p lang="ua">
    <!-- This text will not be translated -->
    Цей текст не буде перекладатись
  </p>
  

</html>