### PR TITLE
Issue#377 | Fix popup width for Firefox Overflow menu

### DIFF
--- a/src/popup/styles/PopupPage.scss
+++ b/src/popup/styles/PopupPage.scss
@@ -7,7 +7,8 @@ body {
   font-family: "Segoe UI", "San Francisco", "Ubuntu", "Fira Sans", "Roboto", "Arial", "Helvetica",
     sans-serif;
   font-size: 13px;
-  width: 348px;
+  width: 100%;
+  min-width: 348px;
   overflow: hidden;
   background-color: var(--main-bg);
 


### PR DESCRIPTION
Issue https://github.com/sienori/simple-translate/issues/377
Fix width for when the extension is displayed in Firefox's Overflow menu. Other scenarios stay as they are.

Before the fix:

Firefox Overflow menu:
![image](https://user-images.githubusercontent.com/16862411/164772980-ab8b00ec-8e4e-4c90-9125-a4533359ae81.png)
Firefox regular:
![image](https://user-images.githubusercontent.com/16862411/164773039-e64210ef-88f7-4b22-b413-7e106d8d71f7.png)
Chrome:
![image](https://user-images.githubusercontent.com/16862411/164773121-41249ccc-401d-4c28-b1ca-dcb250600166.png)


After the fix:

Firefox Overflow menu:
![image](https://user-images.githubusercontent.com/16862411/164771924-bd6a7c82-96dd-4519-bf22-7a01e8e35f7b.png)
Firefox regular:
![image](https://user-images.githubusercontent.com/16862411/164772034-a1483c1b-1303-4c20-b7fc-afa9573f3b42.png)
Chrome:
![image](https://user-images.githubusercontent.com/16862411/164772449-8a42fa42-7547-404e-972c-6c1f955f8087.png)
