### PR TITLE
WYSIWYG IFrame detector 

### DIFF
--- a/src/content/components/TranslateContainer.js
+++ b/src/content/components/TranslateContainer.js
@@ -66,8 +66,8 @@ export default class TranslateContainer extends Component {
     else if (onSelectBehavior === "showPanel") this.showPanel(clickedPosition);
   };
 
-  showButton = clickedPosition => {
-    this.setState({ shouldShowButton: true, buttonPosition: clickedPosition });
+  showButton = () => {
+    this.setState({ shouldShowButton: true, buttonPosition: this.selectedPosition });
   };
 
   hideButton = () => {

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -92,13 +92,14 @@ const getSelectedText = () => {
 
 const getSelectedPosition = () => {
   const element = document.activeElement;
-  const isInTextField = element.tagName === "INPUT" || element.tagName === "TEXTAREA";
-  const selectedRect = isInTextField
+  const isInIframe = element.ownerDocument.defaultView.frameElement;
+  const isInTextField =
+    element.tagName === "INPUT" || element.tagName === "TEXTAREA";
+  const selectedRect = isInIframe
+    ? element.ownerDocument.defaultView.frameElement.getBoundingClientRect()
+    : isInTextField
     ? element.getBoundingClientRect()
-    : window
-      .getSelection()
-      .getRangeAt(0)
-      .getBoundingClientRect();
+    : window.getSelection().getRangeAt(0).getBoundingClientRect();
 
   let selectedPosition;
   const panelReferencePoint = getSettings("panelReferencePoint");
@@ -199,7 +200,7 @@ const disableExtensionByUrlList = () => {
 };
 
 const removeTranslatecontainer = async () => {
-  const element = document.getElementById("simple-translate");
+  const element = window.parent.document.getElementById("simple-translate");
   if (!element) return;
 
   ReactDOM.unmountComponentAtNode(element);
@@ -212,13 +213,13 @@ const showTranslateContainer = (
   clickedPosition = null,
   shouldTranslate = false
 ) => {
-  const element = document.getElementById("simple-translate");
+  const element = window.parent.document.getElementById("simple-translate");
   if (element) return;
   if (!isEnabled) return;
 
   const themeClass = "simple-translate-" + getSettings("theme") + "-theme";
 
-  document.body.insertAdjacentHTML("beforeend", `<div id="simple-translate" class="${themeClass}"></div>`);
+  window.parent.document.body.insertAdjacentHTML("beforeend", `<div id="simple-translate" class="${themeClass}"></div>`);
   ReactDOM.render(
     <TranslateContainer
       removeContainer={removeTranslatecontainer}
@@ -227,6 +228,6 @@ const showTranslateContainer = (
       clickedPosition={clickedPosition}
       shouldTranslate={shouldTranslate}
     />,
-    document.getElementById("simple-translate")
+    window.parent.document.getElementById("simple-translate")
   );
 };


### PR DESCRIPTION
Due to the insertion of this extension, if we use it inside WYSIWYG, it detects the simple-translate elements as an element inside WYSIWYG; this causes a problem if you upload the source code of the WYSIWYG to the database, which will still have the simple-translate container.

The button to show the panel is going to show under the frame, but still, everything else will work as it were if it's not inside iframe of WYSIWYG

This video shows how the source code insert inside the iframe


https://user-images.githubusercontent.com/39845181/215542553-3bc0d6be-781c-42d7-b467-4a38fe7b98a9.mp4

However, this video shows how the extension works as before, but inside iframe it detects that and inserts the HTML source code outside it.


https://user-images.githubusercontent.com/39845181/215543714-7167acd7-d4c7-43e3-881a-6a6954ddf029.mp4


