### PR TITLE
Replace input field text with translation

### DIFF
--- a/src/content/components/TranslateContainer.js
+++ b/src/content/components/TranslateContainer.js
@@ -11,6 +11,17 @@ const translateText = async (text, targetLang = getSettings("targetLang")) => {
   return result;
 };
 
+export const autoTranslateText = async (text) => {
+  let result = await translateText(text);
+  const targetLang = getSettings("targetLang");
+  const secondLang = getSettings("secondTargetLang");
+  const shouldSwitchSecondLang =
+    getSettings("ifChangeSecondLangOnPage") &&
+    result.sourceLanguage.split("-")[0] === targetLang.split("-")[0] && result.percentage > 0 && targetLang !== secondLang;
+  if (shouldSwitchSecondLang) result = await translateText(text, secondLang);
+  return result
+}
+
 const matchesTargetLang = async selectedText => {
   const targetLang = getSettings("targetLang");
   //detectLanguageで判定
@@ -84,14 +95,7 @@ export default class TranslateContainer extends Component {
     const panelReferencePoint = getSettings("panelReferencePoint");
     const useClickedPosition = panelReferencePoint === "clickedPoint" && clickedPosition !== null;
     const panelPosition = useClickedPosition ? clickedPosition : this.selectedPosition;
-
-    let result = await translateText(this.selectedText);
-    const targetLang = getSettings("targetLang");
-    const secondLang = getSettings("secondTargetLang");
-    const shouldSwitchSecondLang =
-      getSettings("ifChangeSecondLangOnPage") &&
-      result.sourceLanguage.split("-")[0] === targetLang.split("-")[0] && result.percentage > 0 && targetLang !== secondLang;
-    if (shouldSwitchSecondLang) result = await translateText(this.selectedText, secondLang);
+    const result = autoTranslateText(this.selectedText);
 
     this.setState({
       shouldShowPanel: true,


### PR DESCRIPTION
When pressing Ctrl+Space in an editable field or textarea, I want Simple Translate to replace the field contents with translated text -- instead of the current behavior of displaying the popup.

If there is no selection, the whole input field is translated.

This PR is incomplete, but functional enough for my use case.

- [ ] Add error handling
- [ ] Add setting to enable/disable the new behavior? (what should be the default?)
- [ ] Move `autoTranslateText` and `translateText` code to another module.
- [ ] What to do when there are multiple translation candidates?
- [ ] No support for `contenteditable` fields -- might be too complicated.
