### PR TITLE
Replace unload event with visibilitychange

### DIFF
--- a/src/content/index.js
+++ b/src/content/index.js
@@ -9,7 +9,7 @@ const init = async () => {
   await initSettings();
   document.addEventListener("mouseup", handleMouseUp);
   document.addEventListener("keydown", handleKeyDown);
-  window.addEventListener("unload", onUnload, { once: true });
+  document.addEventListener("visibilitychange", handleVisibilityChange);
   browser.storage.onChanged.addListener(handleSettingsChange);
   browser.runtime.onMessage.addListener(handleMessage);
   overWriteLogLevel();
@@ -133,8 +133,12 @@ const handleKeyDown = e => {
   }
 };
 
-const onUnload = () => {
-  browser.storage.onChanged.removeListener(handleSettingsChange);
+const handleVisibilityChange = () => {
+  if (document.visibilityState === "hidden") {
+    browser.storage.onChanged.removeListener(handleSettingsChange);
+  } else {
+    browser.storage.onChanged.addListener(handleSettingsChange);
+  }
 };
 
 let isEnabled = true;


### PR DESCRIPTION
The unload event is [incompatible with bfcache](https://developer.mozilla.org/en-US/docs/Web/API/Window/unload_event#usage_notes), which makes the whole browser feel slower when using this extension.

The code responsible for the problem was trying to solve https://github.com/sienori/simple-translate/issues/213, which I could neither reproduce in my Firefox 115 nor find similar reports on the web from recent versions of firefox, so maybe Firefox already solved it and just reverting https://github.com/sienori/simple-translate/commit/b5d5970a854fd7f96ca42842d0096d2ee8e6cda8 is fine.



This also solves https://github.com/sienori/simple-translate/issues/445.

