### PR TITLE
Added Deepl API Pro interface (for Chinese users)

### DIFF
--- a/src/common/translate.js
+++ b/src/common/translate.js
@@ -74,9 +74,12 @@ const sendRequestToDeepL = async (word, sourceLang, targetLang) => {
   params.append("auth_key", authKey);
   params.append("text", word);
   params.append("target_lang", targetLang);
-  const url = getSettings("deeplPlan") === "deeplFree" ?
-    "https://api-free.deepl.com/v2/translate" :
-    "https://api.deepl.com/v2/translate";
+  const url =
+    getSettings("deeplPlan") === "deeplFree"
+      ? "https://api-free.deepl.com/v2/translate"
+      : authKey.endsWith(":dp")
+      ? "https://api.deepl-pro.com/v2/translate"
+      : "https://api.deepl.com/v2/translate";
   const result = await axios.post(url, params).catch(e => e.response);
 
   const resultData = {


### PR DESCRIPTION
Deepl is not yet operational in China, and Chinese users do not have access to the API, but they can get it via https://deepl-pro.com. This is a test auth_key: de14950b-8c5d-41e6-b730-18c2f2a0dfad:dp

目前Deepl尚未在中国开展业务，中国用户无法获取到API，但是他们可以通过https://deepl-pro.com 获取api。