### PR TITLE
Rename container div to #simple-translate-container

### DIFF
--- a/src/content/index.js
+++ b/src/content/index.js
@@ -32,8 +32,8 @@ const handleMouseUp = async e => {
   if (inCodeElement && getSettings("isDisabledInCodeElement")) return;
 
   const isInThisElement =
-    document.querySelector("#simple-translate") &&
-    document.querySelector("#simple-translate").contains(e.target);
+    document.querySelector("#simple-translate-container") &&
+    document.querySelector("#simple-translate-container").contains(e.target);
   if (isInThisElement) return;
 
   removeTranslatecontainer();
@@ -203,7 +203,7 @@ const disableExtensionByUrlList = () => {
 };
 
 const removeTranslatecontainer = async () => {
-  const element = document.getElementById("simple-translate");
+  const element = document.getElementById("simple-translate-container");
   if (!element) return;
 
   ReactDOM.unmountComponentAtNode(element);
@@ -216,13 +216,13 @@ const showTranslateContainer = (
   clickedPosition = null,
   shouldTranslate = false
 ) => {
-  const element = document.getElementById("simple-translate");
+  const element = document.getElementById("simple-translate-container");
   if (element) return;
   if (!isEnabled) return;
 
   const themeClass = "simple-translate-" + getSettings("theme") + "-theme";
 
-  document.body.insertAdjacentHTML("beforeend", `<div id="simple-translate" class="${themeClass}"></div>`);
+  document.body.insertAdjacentHTML("beforeend", `<div id="simple-translate-container" class="${themeClass}"></div>`);
   ReactDOM.render(
     <TranslateContainer
       removeContainer={removeTranslatecontainer}
@@ -231,6 +231,6 @@ const showTranslateContainer = (
       clickedPosition={clickedPosition}
       shouldTranslate={shouldTranslate}
     />,
-    document.getElementById("simple-translate")
+    document.getElementById("simple-translate-container")
   );
 };

--- a/src/content/styles/TranslateButton.scss
+++ b/src/content/styles/TranslateButton.scss
@@ -1,4 +1,4 @@
-#simple-translate {
+#simple-translate-container {
   .simple-translate-button {
     all: initial;
     background-color: var(--simple-translate-main-bg);

--- a/src/content/styles/TranslateContainer.scss
+++ b/src/content/styles/TranslateContainer.scss
@@ -1,4 +1,4 @@
-#simple-translate {
+#simple-translate-container {
   all: initial;
   & > div {
     all: initial;

--- a/src/content/styles/TranslatePanel.scss
+++ b/src/content/styles/TranslatePanel.scss
@@ -1,4 +1,4 @@
-#simple-translate {
+#simple-translate-container {
   .simple-translate-panel {
     all: initial;
     position: fixed;


### PR DESCRIPTION
Closes #521.

I have a blog created using Astro on which I posted about Simple Translate. When Astro converts the Markdown header to HTML it automatically gives the h3 an ID matching the text of the header. In this case, that's `<h3 id="simple-translate">`.

This happens to conflict with the container div for Simple Translate and causes rendering issues on the page.

Admittedly, an ideal PR might do something like inlining the CSS styles on the proper elements or add a build step to randomize the IDs used for Simple Translate elements. Unfortunately, I'm not that clever so this PR simple renames the container to `simple-translate-container` which I expect is less likely to conflict in the wild.