### PR TITLE
Fix Deepl API authorization

### DIFF
--- a/src/common/translate.js
+++ b/src/common/translate.js
@@ -56,9 +56,10 @@ const sendRequestToGoogle = async (word, sourceLang, targetLang) => {
 };
 
 const sendRequestToDeepL = async (word, sourceLang, targetLang) => {
+  let headers = new URLSearchParams();
   let params = new URLSearchParams();
   const authKey = getSettings("deeplAuthKey");
-  params.append("auth_key", authKey);
+  headers.append("Authorization", `DeepL-Auth-Key ${authKey}`);
   params.append("text", word);
   params.append("target_lang", targetLang);
   const url = getSettings("deeplPlan") === "deeplFree" ?
@@ -67,6 +68,7 @@ const sendRequestToDeepL = async (word, sourceLang, targetLang) => {
 
   const response = await fetch(url, {
     method: "POST",
+    headers: headers,
     body: params
   }).catch(e => ({ status: 0, statusText: '' }));
 


### PR DESCRIPTION
Seems like Deepl API now expects authorization key to be passed in headers instead of body parameters.

Fixes #566