### PR TITLE
Fix popup text field not focusing in Firefox

### DIFF
--- a/src/popup/components/InputArea.js
+++ b/src/popup/components/InputArea.js
@@ -27,6 +27,10 @@ export default class InputArea extends Component {
     this.resizeTextArea();
   };
 
+  componentDidMount = () => {
+    document.body.onfocus = () => this.refs.textarea.focus();
+  };
+
   render() {
     const { inputText, sourceLang } = this.props;
     return (


### PR DESCRIPTION
## Problem
Somehow autoFocus attribute doesn't work properly in Firefox.
The text field focuses 1 out of 10 times at best:

https://github.com/user-attachments/assets/154b56ac-1ddb-4941-ab4b-083eb3e7bbaf

Focus is always set on body element, which is seen when I check ``document.activeElement`` in console after a couple of seconds like this:
```
setTimeout(() => console.log(document.activeElement),2500);
```


## Solution
My solution is simply invoke focus on textarea when the body is focused
```
componentDidMount = () => {
    document.body.onfocus = () => this.refs.textarea.focus();
};
```

https://github.com/user-attachments/assets/02f50764-0219-4d93-ae6f-7c245c33c01c


It works fine as in the video above. I've seen this problem since like 2 years ago, I hope this is a good enough solution for it.