### PR TITLE
Add context menu option to translate image

### DIFF
--- a/src/_locales/af/messages.json
+++ b/src/_locales/af/messages.json
@@ -467,6 +467,9 @@
   "translateLinkMenu": {
     "message": "Translate selected link"
   },
+  "translateImageMenu": {
+    "message": "Translate selected image"
+  },
   "openPopupDescription": {
     "message": "Open toolbar popup"
   },

--- a/src/_locales/ar/messages.json
+++ b/src/_locales/ar/messages.json
@@ -467,6 +467,9 @@
   "translateLinkMenu": {
     "message": "ترجم الرابط المحدد"
   },
+  "translateImageMenu": {
+    "message": "Translate selected image"
+  },
   "openPopupDescription": {
     "message": "فتح شريط الأدوات المنبثق"
   },

--- a/src/_locales/bg/messages.json
+++ b/src/_locales/bg/messages.json
@@ -467,6 +467,9 @@
   "translateLinkMenu": {
     "message": "Преведете избраната връзка"
   },
+  "translateImageMenu": {
+    "message": "Translate selected image"
+  },
   "openPopupDescription": {
     "message": "Open toolbar popup"
   },

--- a/src/_locales/ca/messages.json
+++ b/src/_locales/ca/messages.json
@@ -467,6 +467,9 @@
   "translateLinkMenu": {
     "message": "Tradueix l'enlaç selecionat"
   },
+  "translateImageMenu": {
+    "message": "Translate selected image"
+  },
   "openPopupDescription": {
     "message": "Obri la finestra emergent de la barra d'eines"
   },

--- a/src/_locales/cs/messages.json
+++ b/src/_locales/cs/messages.json
@@ -467,6 +467,9 @@
   "translateLinkMenu": {
     "message": "Translate selected link"
   },
+  "translateImageMenu": {
+    "message": "Translate selected image"
+  },
   "openPopupDescription": {
     "message": "Open toolbar popup"
   },

--- a/src/_locales/da/messages.json
+++ b/src/_locales/da/messages.json
@@ -467,6 +467,9 @@
   "translateLinkMenu": {
     "message": "Translate selected link"
   },
+  "translateImageMenu": {
+    "message": "Translate selected image"
+  },
   "openPopupDescription": {
     "message": "Open toolbar popup"
   },

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -467,6 +467,9 @@
   "translateLinkMenu": {
     "message": "Ausgewählten Link übersetzen"
   },
+  "translateImageMenu": {
+    "message": "Translate selected image"
+  },
   "openPopupDescription": {
     "message": "Toolbar-Popup öffnen"
   },

--- a/src/_locales/el/messages.json
+++ b/src/_locales/el/messages.json
@@ -467,6 +467,9 @@
   "translateLinkMenu": {
     "message": "Μετάφραση του επιλεγμένου συνδέσμου"
   },
+  "translateImageMenu": {
+    "message": "Translate selected image"
+  },
   "openPopupDescription": {
     "message": "Άνοιγμα του αναδυόμενου παραθύρου της γραμμής εργαλείων"
   },

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -467,6 +467,9 @@
   "translateLinkMenu": {
     "message": "Translate selected link"
   },
+  "translateImageMenu": {
+    "message": "Translate selected image"
+  },
   "openPopupDescription": {
     "message": "Open toolbar popup"
   },

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -467,6 +467,9 @@
   "translateLinkMenu": {
     "message": "Traducir enlace seleccionado"
   },
+  "translateImageMenu": {
+    "message": "Translate selected image"
+  },
   "openPopupDescription": {
     "message": "Abrir la ventana emergente de la barra de herramientas"
   },

--- a/src/_locales/fi/messages.json
+++ b/src/_locales/fi/messages.json
@@ -467,6 +467,9 @@
   "translateLinkMenu": {
     "message": "Käännä valittu linkki"
   },
+  "translateImageMenu": {
+    "message": "Translate selected image"
+  },
   "openPopupDescription": {
     "message": "Avaa työkalupalkin ponnahdus"
   },

--- a/src/_locales/fil/messages.json
+++ b/src/_locales/fil/messages.json
@@ -467,6 +467,9 @@
   "translateLinkMenu": {
     "message": "Isalin ang piniling link"
   },
+  "translateImageMenu": {
+    "message": "Translate selected image"
+  },
   "openPopupDescription": {
     "message": "Open toolbar popup"
   },

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -467,6 +467,9 @@
   "translateLinkMenu": {
     "message": "Traduire le lien sélectionné"
   },
+  "translateImageMenu": {
+    "message": "Translate selected image"
+  },
   "openPopupDescription": {
     "message": "Ouvrir la barre d’outil en pop-up"
   },

--- a/src/_locales/he/messages.json
+++ b/src/_locales/he/messages.json
@@ -467,6 +467,9 @@
   "translateLinkMenu": {
     "message": "תרגם קישור מסומן"
   },
+  "translateImageMenu": {
+    "message": "Translate selected image"
+  },
   "openPopupDescription": {
     "message": "פתח את פופאפ סרגל הכלים"
   },

--- a/src/_locales/hu/messages.json
+++ b/src/_locales/hu/messages.json
@@ -467,6 +467,9 @@
   "translateLinkMenu": {
     "message": "A kijelölt hivatkozás fordítása"
   },
+  "translateImageMenu": {
+    "message": "Translate selected image"
+  },
   "openPopupDescription": {
     "message": "Eszköztár felugró ablak megnyitása"
   },

--- a/src/_locales/id/messages.json
+++ b/src/_locales/id/messages.json
@@ -467,6 +467,9 @@
   "translateLinkMenu": {
     "message": "Terjemahkan tautan terpilih"
   },
+  "translateImageMenu": {
+    "message": "Translate selected image"
+  },
   "openPopupDescription": {
     "message": "Buka sembulan bilah alat"
   },

--- a/src/_locales/it/messages.json
+++ b/src/_locales/it/messages.json
@@ -467,6 +467,9 @@
   "translateLinkMenu": {
     "message": "Traduci il collegamento selezionato"
   },
+  "translateImageMenu": {
+    "message": "Translate selected image"
+  },
   "openPopupDescription": {
     "message": "Apri il popup della barra degli strumenti"
   },

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -467,6 +467,9 @@
   "translateLinkMenu": {
     "message": "選択したリンクを翻訳"
   },
+  "translateImageMenu": {
+    "message": "Translate selected image"
+  },
   "openPopupDescription": {
     "message": "ツールバーポップアップを開く"
   },

--- a/src/_locales/ko/messages.json
+++ b/src/_locales/ko/messages.json
@@ -467,6 +467,9 @@
   "translateLinkMenu": {
     "message": "선택한 링크 번역"
   },
+  "translateImageMenu": {
+    "message": "Translate selected image"
+  },
   "openPopupDescription": {
     "message": "툴바 팝업 열기"
   },

--- a/src/_locales/nl/messages.json
+++ b/src/_locales/nl/messages.json
@@ -467,6 +467,9 @@
   "translateLinkMenu": {
     "message": "Geselecteerde link vertalen"
   },
+  "translateImageMenu": {
+    "message": "Translate selected image"
+  },
   "openPopupDescription": {
     "message": "Open toolbar popup"
   },

--- a/src/_locales/no/messages.json
+++ b/src/_locales/no/messages.json
@@ -467,6 +467,9 @@
   "translateLinkMenu": {
     "message": "Omset merka lenke"
   },
+  "translateImageMenu": {
+    "message": "Translate selected image"
+  },
   "openPopupDescription": {
     "message": "Opna sprettoppvindauget"
   },

--- a/src/_locales/pl/messages.json
+++ b/src/_locales/pl/messages.json
@@ -467,6 +467,9 @@
   "translateLinkMenu": {
     "message": "Przetłumacz wybrany link"
   },
+  "translateImageMenu": {
+    "message": "Translate selected image"
+  },
   "openPopupDescription": {
     "message": "Otwórz okienko paska narzędzi"
   },

--- a/src/_locales/pt/messages.json
+++ b/src/_locales/pt/messages.json
@@ -467,6 +467,9 @@
   "translateLinkMenu": {
     "message": "Traduzir link selecionado"
   },
+  "translateImageMenu": {
+    "message": "Translate selected image"
+  },
   "openPopupDescription": {
     "message": "Abrir popup da barra de ferramentas"
   },

--- a/src/_locales/ro/messages.json
+++ b/src/_locales/ro/messages.json
@@ -467,6 +467,9 @@
   "translateLinkMenu": {
     "message": "Tradu link-ul selectat"
   },
+  "translateImageMenu": {
+    "message": "Translate selected image"
+  },
   "openPopupDescription": {
     "message": "Deschide fereastra din bara de instrumente"
   },

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -467,6 +467,9 @@
   "translateLinkMenu": {
     "message": "Перевести страницу по ссылке"
   },
+  "translateImageMenu": {
+    "message": "Translate selected image"
+  },
   "openPopupDescription": {
     "message": "Показать всплывающее окно на панели инструментов"
   },

--- a/src/_locales/sat/messages.json
+++ b/src/_locales/sat/messages.json
@@ -467,6 +467,9 @@
   "translateLinkMenu": {
     "message": "ᱵᱟᱪᱷᱟᱣ ᱠᱟᱱ ᱞᱤᱝᱠ ᱛᱚᱨᱡᱚᱢᱟᱭ ᱢᱮ"
   },
+  "translateImageMenu": {
+    "message": "Translate selected image"
+  },
   "openPopupDescription": {
     "message": "ᱴᱩᱞᱵᱟᱨ ᱯᱚᱯᱚᱯ ᱡᱷᱤᱡᱽ ᱢᱮ"
   },

--- a/src/_locales/si/messages.json
+++ b/src/_locales/si/messages.json
@@ -467,6 +467,9 @@
   "translateLinkMenu": {
     "message": "තේරූ සබැඳිය පරිවර්තනය"
   },
+  "translateImageMenu": {
+    "message": "Translate selected image"
+  },
   "openPopupDescription": {
     "message": "Open toolbar popup"
   },

--- a/src/_locales/sr/messages.json
+++ b/src/_locales/sr/messages.json
@@ -467,6 +467,9 @@
   "translateLinkMenu": {
     "message": "Translate selected link"
   },
+  "translateImageMenu": {
+    "message": "Translate selected image"
+  },
   "openPopupDescription": {
     "message": "Open toolbar popup"
   },

--- a/src/_locales/sv/messages.json
+++ b/src/_locales/sv/messages.json
@@ -467,6 +467,9 @@
   "translateLinkMenu": {
     "message": "Översätt markerad länk"
   },
+  "translateImageMenu": {
+    "message": "Translate selected image"
+  },
   "openPopupDescription": {
     "message": "Öppna verktygsfältspopup"
   },

--- a/src/_locales/tl/messages.json
+++ b/src/_locales/tl/messages.json
@@ -467,6 +467,9 @@
   "translateLinkMenu": {
     "message": "Isalin ang sinilektang link"
   },
+  "translateImageMenu": {
+    "message": "Translate selected image"
+  },
   "openPopupDescription": {
     "message": "Buksan ang toolbar popup"
   },

--- a/src/_locales/tr/messages.json
+++ b/src/_locales/tr/messages.json
@@ -467,6 +467,9 @@
   "translateLinkMenu": {
     "message": "Seçilen linki çevir"
   },
+  "translateImageMenu": {
+    "message": "Translate selected image"
+  },
   "openPopupDescription": {
     "message": "Tarayıcı araç çubuğu penceresini aç"
   },

--- a/src/_locales/uk/messages.json
+++ b/src/_locales/uk/messages.json
@@ -467,6 +467,9 @@
   "translateLinkMenu": {
     "message": "Перекласти вибране посилання"
   },
+  "translateImageMenu": {
+    "message": "Translate selected image"
+  },
   "openPopupDescription": {
     "message": "Показати випадаюче вікно"
   },

--- a/src/_locales/ur/messages.json
+++ b/src/_locales/ur/messages.json
@@ -467,6 +467,9 @@
   "translateLinkMenu": {
     "message": "Translate selected link"
   },
+  "translateImageMenu": {
+    "message": "Translate selected image"
+  },
   "openPopupDescription": {
     "message": "Open toolbar popup"
   },

--- a/src/_locales/vi/messages.json
+++ b/src/_locales/vi/messages.json
@@ -467,6 +467,9 @@
   "translateLinkMenu": {
     "message": "Dịch liên kết đã chọn"
   },
+  "translateImageMenu": {
+    "message": "Translate selected image"
+  },
   "openPopupDescription": {
     "message": "Mở thanh công cụ bật lên"
   },

--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -467,6 +467,9 @@
   "translateLinkMenu": {
     "message": "翻译选中的链接"
   },
+  "translateImageMenu": {
+    "message": "Translate selected image"
+  },
   "openPopupDescription": {
     "message": "打开工具栏弹出窗口"
   },

--- a/src/_locales/zh_TW/messages.json
+++ b/src/_locales/zh_TW/messages.json
@@ -467,6 +467,9 @@
   "translateLinkMenu": {
     "message": "翻譯選取鏈結"
   },
+  "translateImageMenu": {
+    "message": "Translate selected image"
+  },
   "openPopupDescription": {
     "message": "開啟工具列彈出式視窗"
   },


### PR DESCRIPTION
A new right-click option has been added. This option automatically copies the image to the clipboard and opens Google Translate with the appropriate language settings. Only the image pasting is left to the user.
<img width="358" height="153" alt="Screenshot of new context menu option" src="https://github.com/user-attachments/assets/2869f371-b1dc-4891-83c5-f1aee420ba3f" />
