### PR TITLE
feat: Add Firefox sidebar functionality

### DIFF
--- a/src/manifest-firefox.json
+++ b/src/manifest-firefox.json
@@ -38,6 +38,15 @@
     },
     "default_popup": "popup/index.html"
   },
+  "sidebar_action": {
+    "default_title": "__MSG_extName__",
+    "default_panel": "sidebar/index.html",
+    "default_icon": {
+      "48": "icons/48.png",
+      "32": "icons/32.png",
+      "16": "icons/16.png"
+    }
+  },
   "content_scripts": [
     {
       "all_frames": true,

--- a/src/sidebar/index.html
+++ b/src/sidebar/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+  </head>
+
+  <body>
+    <div id="root" />
+  </body>
+</html>

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -1,0 +1,6 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import PopupPage from "../popup/components/PopupPage";
+import "./styles/SidebarPage.scss";
+
+ReactDOM.render(<PopupPage />, document.getElementById("root"));

--- a/src/sidebar/styles/SidebarPage.scss
+++ b/src/sidebar/styles/SidebarPage.scss
@@ -1,0 +1,8 @@
+@import "../../popup/styles/PopupPage.scss";
+
+body {
+  width: 100% !important;
+  min-width: 0 !important;
+  overflow-y: auto !important;
+  overflow-x: hidden;
+}

--- a/webpack.utils.js
+++ b/webpack.utils.js
@@ -21,6 +21,12 @@ const getHTMLPlugins = (browserDir, outputDir = "dev", sourceDir = "src") => [
     filename: path.resolve(__dirname, `${outputDir}/${browserDir}/options/index.html`),
     template: `${sourceDir}/options/index.html`,
     chunks: ["options"]
+  }),
+  new HtmlWebpackPlugin({
+    title: "Sidebar",
+    filename: path.resolve(__dirname, `${outputDir}/${browserDir}/sidebar/index.html`),
+    template: `${sourceDir}/sidebar/index.html`,
+    chunks: ["sidebar"]
   })
 ];
 
@@ -36,7 +42,8 @@ const getEntry = (sourceDir = "src") => {
     popup: path.resolve(__dirname, `${sourceDir}/popup/index.js`),
     options: path.resolve(__dirname, `${sourceDir}/options/index.js`),
     content: path.resolve(__dirname, `${sourceDir}/content/index.js`),
-    background: path.resolve(__dirname, `${sourceDir}/background/background.js`)
+    background: path.resolve(__dirname, `${sourceDir}/background/background.js`),
+    sidebar: path.resolve(__dirname, `${sourceDir}/sidebar/index.js`)
   };
 };
 


### PR DESCRIPTION
Add sidebar support for Firefox so users can open the Simple Translate UI in the browser sidebar (View → Sidebar → Simple Translate).

Changes:
- Added `sidebar_action` key to `manifest-firefox.json`
- Created new `src/sidebar/` directory with entry point that reuses the existing `PopupPage` component
- Updated webpack build configuration to include the sidebar entry point
- Sidebar styles override the popup's fixed width to fill the sidebar panel