### PR TITLE
Add URL-scoped text field translation disable rule

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -140,6 +140,12 @@
   "isDisabledInTextFieldsCaptionLabel": {
     "message": "Don't display translation button or panel when selecting text in a text field."
   },
+  "disableInTextFieldsUrlListLabel": {
+    "message": "URL list to disable translation in text fields"
+  },
+  "disableInTextFieldsUrlListCaptionLabel": {
+    "message": "If the page URL matches this list, translation is disabled only when selecting text in a text field or editable document. This works independently of the global checkbox above. The list allows \"*\" wildcards."
+  },
   "isDisabledInCodeElementLabel": {
     "message": "Disable translation in code tags"
   },

--- a/src/background/menus.js
+++ b/src/background/menus.js
@@ -19,6 +19,9 @@ export const onMenusShownListener = (info, tab) => {
   } else {
     browser.contextMenus.update("translatePage", { visible: true });
   }
+  const shouldHideTextTranslation =
+    info.contexts.includes("selection") && isTextFieldTranslationDisabledInContext(info, tab);
+  browser.contextMenus.update("translateText", { visible: !shouldHideTextTranslation });
   browser.contextMenus.refresh();
 };
 
@@ -30,7 +33,7 @@ export const onMenusClickedListener = (info, tab) => {
       translatePage(info, tab);
       break;
     case "translateText":
-      translateText(tab);
+      translateText(info, tab);
       break;
     case "translateLink":
       translateLink(info, tab);
@@ -72,7 +75,33 @@ function removeMenus() {
   browser.contextMenus.removeAll();
 }
 
-function translateText(tab) {
+function isTextFieldTranslationDisabledInContext(info, tab) {
+  if (!isEditableContext(info)) return false;
+  return (
+    getSettings("isDisabledInTextFields") ||
+    matchesUrlList(getSettings("disableInTextFieldsUrlList"), getContextUrls(info, tab))
+  );
+}
+
+function isEditableContext(info) {
+  return info.editable || info.contexts.includes("editable");
+}
+
+function getContextUrls(info, tab) {
+  return [info.pageUrl, info.frameUrl, tab?.url].filter(Boolean);
+}
+
+function matchesUrlList(urlList, pageUrls) {
+  return urlList.split("\n").some(urlPattern => {
+    const pattern = urlPattern
+      .trim()
+      .replace(/[-[\]{}()*+?.,\\^$|#\s]/g, match => (match === "*" ? ".*" : "\\" + match));
+    if (pattern === "") return false;
+    return pageUrls.some(pageUrl => RegExp("^" + pattern + "$").test(pageUrl));
+  });
+}
+
+function translateText(info, tab) {
   browser.tabs.sendMessage(tab.id, {
     message: "translateSelectedText"
   });

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -52,9 +52,7 @@ const handleMouseUp = async e => {
   prevSelectedText = selectedText;
   if (selectedText.length === 0) return;
 
-  if (getSettings("isDisabledInTextFields")) {
-    if (isInContentEditable()) return;
-  }
+  if (shouldDisableTranslationInTextFields(e.target)) return;
 
   if (getSettings("ifOnlyTranslateWhenModifierKeyPressed")) {
     const modifierKey = getSettings("modifierKey");
@@ -121,11 +119,79 @@ const getSelectedPosition = () => {
   return selectedPosition;
 };
 
-const isInContentEditable = () => {
-  const element = document.activeElement;
+const isEditableElement = element => {
+  if (!element || !element.tagName) return false;
   if (element.tagName === "INPUT" || element.tagName === "TEXTAREA") return true;
-  if (element.contentEditable === "true") return true;
+  return isContentEditableElement(element);
+};
+
+const isTextInputElement = element => {
+  if (!element || !element.tagName) return false;
+  return element.tagName === "INPUT" || element.tagName === "TEXTAREA";
+};
+
+const isContentEditableElement = element => {
+  if (!element || !element.tagName) return false;
+  if (element.isContentEditable) return true;
+  if (element.closest) {
+    return !!element.closest(
+      '[contenteditable=""], [contenteditable="true"], [contenteditable="plaintext-only"]'
+    );
+  }
   return false;
+};
+
+const getSelectionElement = () => {
+  const selection = window.getSelection();
+  const node = selection?.anchorNode || selection?.focusNode;
+  if (!node) return null;
+  return node.nodeType === Node.ELEMENT_NODE ? node : node.parentElement;
+};
+
+const isEditableDocument = () => {
+  return (
+    document.designMode === "on" ||
+    document.body?.isContentEditable ||
+    document.documentElement?.isContentEditable
+  );
+};
+
+const isInTextFieldOrContentEditable = target => {
+  return isEditableElement(target) || isSelectionInEditableContext();
+};
+
+const isSelectionInEditableContext = () => {
+  return (
+    isEditableDocument() ||
+    isContentEditableElement(getSelectionElement()) ||
+    isTextInputElement(document.activeElement)
+  );
+};
+
+const getPageUrl = () => {
+  try {
+    return top.location.href;
+  } catch (e) {
+    return document.referrer;
+  }
+};
+
+const matchesUrlList = urlList => {
+  const pageUrl = getPageUrl();
+  return urlList.split("\n").some(urlPattern => {
+    const pattern = urlPattern
+      .trim()
+      .replace(/[-[\]{}()*+?.,\\^$|#\s]/g, match => (match === "*" ? ".*" : "\\" + match));
+    if (pattern === "") return false;
+    return RegExp("^" + pattern + "$").test(pageUrl);
+  });
+};
+
+const shouldDisableTranslationInTextFields = target => {
+  const isConfigured =
+    getSettings("isDisabledInTextFields") ||
+    matchesUrlList(getSettings("disableInTextFieldsUrlList"));
+  return isConfigured && isInTextFieldOrContentEditable(target);
 };
 
 const handleKeyDown = e => {
@@ -163,6 +229,7 @@ const handleMessage = async request => {
       if (!isEnabled) return empty;
       const selectedText = getSelectedText();
       if (selectedText.length === 0) return;
+      if (shouldDisableTranslationInTextFields()) return;
       const selectedPosition = getSelectedPosition();
       removeTranslatecontainer();
       showTranslateContainer(selectedText, selectedPosition, null, true);
@@ -183,24 +250,7 @@ const handleMessage = async request => {
 };
 
 const disableExtensionByUrlList = () => {
-  const disableUrls = getSettings("disableUrlList").split("\n");
-  let pageUrl;
-  try {
-    pageUrl = top.location.href;
-  } catch (e) {
-    pageUrl = document.referrer;
-  }
-
-  const matchesPageUrl = urlPattern => {
-    const pattern = urlPattern
-      .trim()
-      .replace(/[-[\]{}()*+?.,\\^$|#\s]/g, match => (match === "*" ? ".*" : "\\" + match));
-    if (pattern === "") return false;
-    return RegExp("^" + pattern + "$").test(pageUrl);
-  };
-
-  const isMatched = disableUrls.some(matchesPageUrl);
-  if (isMatched) isEnabled = false;
+  if (matchesUrlList(getSettings("disableUrlList"))) isEnabled = false;
 };
 
 const removeTranslatecontainer = async () => {

--- a/src/settings/defaultSettings.js
+++ b/src/settings/defaultSettings.js
@@ -251,6 +251,14 @@ export default [
             default: false
           },
           {
+            id: "disableInTextFieldsUrlList",
+            title: "disableInTextFieldsUrlListLabel",
+            captions: ["disableInTextFieldsUrlListCaptionLabel"],
+            type: "textarea",
+            default: "",
+            placeholder: "https://example.com/*\n*confluence*"
+          },
+          {
             id: "isDisabledInCodeElement",
             title: "isDisabledInCodeElementLabel",
             captions: ["isDisabledInCodeElementCaptionLabel"],


### PR DESCRIPTION
## Summary

- Add an optional URL list that disables translation only inside text fields and editable documents on matching pages.
- Keep the existing "Disable translation in text fields" checkbox as a global rule.
- Hide the "Translate selected text" context menu item only when the current context is editable and the global or URL-scoped text-field rule applies.
- Keep translation available for static page text on the same URL.

## Motivation

Some rich text editors persist extension-injected UI into the edited document when translation is triggered inside the editable area. A global "Disable translation in text fields" setting prevents this everywhere, but it is broader than necessary. The URL-scoped rule lets users protect specific sites with rich editors while keeping normal text-field translation behavior elsewhere.

## Implementation notes

- The new `disableInTextFieldsUrlList` setting is independent of `isDisabledInTextFields`.
- Matching uses the same `*` wildcard style as the existing disabled URL list.
- The content script checks the rule for selection button/panel flows and context-menu-triggered selected text translation.
- The background context menu logic hides "Translate selected text" only for editable contexts where the rule applies.

## Validation

- `npm run format:check`
- `npm run build`
- Manual Firefox test on a rich text editor page:
  - URL-scoped rule enabled for the editor site.
  - Static text outside the editor remained translatable.
  - Text selected inside the editor did not show the translation UI.
  - The selected-text context menu item was hidden inside the editor.
  - Saving the edited page did not persist extension UI markup.
