### PR TITLE
Add Hebrew (he) to DeepL supported language list

### DIFF
--- a/src/common/generateLangOptions.js
+++ b/src/common/generateLangOptions.js
@@ -123,6 +123,7 @@ const langListDeepl = [
   "et",
   "fi",
   "fr",
+  "he",
   "hu",
   "id",
   "it",


### PR DESCRIPTION
DeepL API supports Hebrew as a target language, but it was missing from the extension's hardcoded DeepL language list, preventing users with DeepL API keys from selecting Hebrew as a target language.